### PR TITLE
register parameters with service container

### DIFF
--- a/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
+++ b/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
@@ -21,7 +21,14 @@ use Silex\ServiceProviderInterface;
 class ServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
-    {
+    {        
+        // register parameters with service container
+        $app['memcache.class']              = $this->getMemcacheClass($app);
+        $app['memcache.wrapper']            = $this->getWrapperClass($app);
+        $app['memcache.connections']        = $this->getConnections($app);
+        $app['memcache.default_duration']   = $this->getDefaultExpirationTime($app);
+        $app['memcache.default_compress']   = $this->getDefaultCompress($app);
+        
         $app['memcache'] = $app->share(function() use ($app) {
             $memcacheClass = $this->getMemcacheClass($app);
             $memcacheInstance = new $memcacheClass();
@@ -36,13 +43,11 @@ class ServiceProvider implements ServiceProviderInterface
             }
 
             return new $wrapperClass($memcacheInstance, $app);
-        });
+        });        
     }
 
     public function boot(Application $app)
     {
-        $app['memcache.default_duration'] = $this->getDefaultExpirationTime($app);
-        $app['memcache.default_compress'] = $this->getDefaultCompress($app);
     }
 
     public function getMemcacheClass(Application $app)


### PR DESCRIPTION
Currently, parameters aren't actually set unless the user specifies them when registering the provider. Any code that then tries to access these, ends up throwing exceptions. Moving them to register ensures all required parameters are created after the provider is registered.

Right now, trying to set values will fail if 'memcache.default_compress' hasn't been set. Same with any of the other parameters.

@SimpleWrapper:29
$compress = $this->app['memcache.default_compress'];
