### PR TITLE
Adapt to Silex 1.3:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require-dev": {
-        "silex/silex": "1.0.*",
+        "silex/silex": "~2.0@dev",
         "atoum/atoum": "dev-master"
     },
     "autoload": {

--- a/src/KuiKui/MemcacheServiceProvider/AbstractWrapper.php
+++ b/src/KuiKui/MemcacheServiceProvider/AbstractWrapper.php
@@ -10,7 +10,7 @@
 
 namespace KuiKui\MemcacheServiceProvider;
 
-use Silex\Application;
+use Pimple\Container as Application;
 
 /**
  * Memcache wrapper interface.

--- a/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
+++ b/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
@@ -10,8 +10,8 @@
 
 namespace KuiKui\MemcacheServiceProvider;
 
-use Silex\Application;
-use Silex\ServiceProviderInterface;
+use Pimple\ServiceProviderInterface;
+use Pimple\Container as Application;
 
 /**
  * Memcache service provider.
@@ -24,7 +24,7 @@ class ServiceProvider implements ServiceProviderInterface
     {
         // Storing the provider to be able to inject it into the closure, allowing the closure to access the provider.
         $provider = $this;
-        $app['memcache'] = $app->share(function() use ($app, $provider) {
+        $app['memcache'] = ( function() use ($app, $provider) {
             $memcacheClass = $provider->getMemcacheClass($app);
             $memcacheInstance = new $memcacheClass();
 
@@ -39,10 +39,6 @@ class ServiceProvider implements ServiceProviderInterface
 
             return new $wrapperClass($memcacheInstance, $app);
         });
-    }
-
-    public function boot(Application $app)
-    {
         $app['memcache.default_duration'] = $this->getDefaultExpirationTime($app);
         $app['memcache.default_compress'] = $this->getDefaultCompress($app);
     }

--- a/src/KuiKui/MemcacheServiceProvider/SimpleWrapper.php
+++ b/src/KuiKui/MemcacheServiceProvider/SimpleWrapper.php
@@ -10,8 +10,6 @@
 
 namespace KuiKui\MemcacheServiceProvider;
 
-use Silex\Application;
-
 /**
  * Memcache simple wrapper.
  *

--- a/tests/units/KuiKui/MemcacheServiceProvider/ServiceProvider.php
+++ b/tests/units/KuiKui/MemcacheServiceProvider/ServiceProvider.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/../../../bootstrap.php';
 
 use mageekguy\atoum;
 use KuiKui\MemcacheServiceProvider;
-use Silex\Application;
+use Pimple\Container as Application;
 
 class ServiceProvider extends atoum\test
 {

--- a/tests/units/KuiKui/MemcacheServiceProvider/SimpleWrapper.php
+++ b/tests/units/KuiKui/MemcacheServiceProvider/SimpleWrapper.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/../../../bootstrap.php';
 
 use mageekguy\atoum;
 use KuiKui\MemcacheServiceProvider;
-use Silex\Application;
+use Pimple\Container as Application;
 
 class SimpleWrapper extends atoum\test
 {


### PR DESCRIPTION
It was not working on my Silex 1.3 project, so I made it work, 
I could not verify the tests were working though. 
Here's the list of changes:
- Pimple\Container as Application instead of Silex\Application
- Pimple\ServiceProviderInterface instead of Silex\ServiceProviderInterface
- Removed the boot function in ServiceProvider and put its content at the bottom of Register function.
- Fixed the tests too