### PR TITLE
adapt provider for Silex ~2.0@dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 5.5
 
 before_script:
   - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
updated the provider to work with https://github.com/silexphp/Silex-Skeleton
requirements: 
- "php": ">=5.5.9",
- "silex/silex": "~2.0@dev",

my first pull request, sorry for wrong branch name.