### PR TITLE
adapt provider for Silex ~2.0@dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 5.5
 
 before_script:
   - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require-dev": {
-        "silex/silex": "1.0.*",
+        "silex/silex": "~2.0@dev",
         "atoum/atoum": "dev-master"
     },
     "autoload": {

--- a/src/KuiKui/MemcacheServiceProvider/AbstractWrapper.php
+++ b/src/KuiKui/MemcacheServiceProvider/AbstractWrapper.php
@@ -10,7 +10,7 @@
 
 namespace KuiKui\MemcacheServiceProvider;
 
-use Silex\Application;
+use Pimple\Container as Application;
 
 /**
  * Memcache wrapper interface.

--- a/src/KuiKui/MemcacheServiceProvider/AbstractWrapper.php
+++ b/src/KuiKui/MemcacheServiceProvider/AbstractWrapper.php
@@ -10,7 +10,7 @@
 
 namespace KuiKui\MemcacheServiceProvider;
 
-use Pimple\Container as Application;
+use Silex\Application;
 
 /**
  * Memcache wrapper interface.

--- a/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
+++ b/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
@@ -11,16 +11,18 @@
 namespace KuiKui\MemcacheServiceProvider;
 
 use Pimple\ServiceProviderInterface;
-use Pimple\Container as Application;
+use Pimple\Container;
+use Silex\Application;
+use Silex\Api\BootableProviderInterface;
 
 /**
  * Memcache service provider.
  *
  * @author Denis Roussel <denis.roussel@gmail.com>
  */
-class ServiceProvider implements ServiceProviderInterface
+class ServiceProvider implements ServiceProviderInterface, BootableProviderInterface
 {
-    public function register(Application $app)
+    public function register(Container $app)
     {
         // Storing the provider to be able to inject it into the closure, allowing the closure to access the provider.
         $provider = $this;
@@ -39,11 +41,14 @@ class ServiceProvider implements ServiceProviderInterface
 
             return new $wrapperClass($memcacheInstance, $app);
         });
-        
+    }
+    
+    public function boot(Application $app)
+    {
         $app['memcache.default_duration'] = $this->getDefaultExpirationTime($app);
         $app['memcache.default_compress'] = $this->getDefaultCompress($app);
     }
-
+    
     public function getMemcacheClass(Application $app)
     {
         if (!isset($app['memcache.class'])) {

--- a/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
+++ b/src/KuiKui/MemcacheServiceProvider/ServiceProvider.php
@@ -10,8 +10,8 @@
 
 namespace KuiKui\MemcacheServiceProvider;
 
-use Silex\Application;
-use Silex\ServiceProviderInterface;
+use Pimple\ServiceProviderInterface;
+use Pimple\Container as Application;
 
 /**
  * Memcache service provider.
@@ -24,7 +24,7 @@ class ServiceProvider implements ServiceProviderInterface
     {
         // Storing the provider to be able to inject it into the closure, allowing the closure to access the provider.
         $provider = $this;
-        $app['memcache'] = $app->share(function() use ($app, $provider) {
+        $app['memcache'] = ( function() use ($app, $provider) {
             $memcacheClass = $provider->getMemcacheClass($app);
             $memcacheInstance = new $memcacheClass();
 
@@ -39,10 +39,7 @@ class ServiceProvider implements ServiceProviderInterface
 
             return new $wrapperClass($memcacheInstance, $app);
         });
-    }
-
-    public function boot(Application $app)
-    {
+        
         $app['memcache.default_duration'] = $this->getDefaultExpirationTime($app);
         $app['memcache.default_compress'] = $this->getDefaultCompress($app);
     }

--- a/src/KuiKui/MemcacheServiceProvider/SimpleWrapper.php
+++ b/src/KuiKui/MemcacheServiceProvider/SimpleWrapper.php
@@ -10,7 +10,6 @@
 
 namespace KuiKui\MemcacheServiceProvider;
 
-use Silex\Application;
 
 /**
  * Memcache simple wrapper.


### PR DESCRIPTION
I need this Provider for my Silex 2.0 project, so I adapted it. 
Tests are passing on Travis CI. 
If I missed something please let me know.

Silex 2.0 requires Php 5.5 or greater.
The register function needs the Pimple\Container as Parameter
The boot function needs the Silex\Application as Parameter
The ServiceProvider extends the BootableProviderInterface
Services are shared by default on Silex 2.0

Cheers. 
